### PR TITLE
CSS imports are mixed with absolute imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullfabric/prettier-cfg",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullfabric/prettier-cfg",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullfabric/prettier-cfg",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Prettier config for FullFabric projects.",
   "main": "index.js",
   "scripts": {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -23,7 +23,7 @@ module.exports = {
     '^shared/?',
     '',
     '^(containers|reducers|actions)(/|$)', // for projects with redux
-    '^(api|context|hooks|constants|utils|components|pages|i18n|apps)(/|$)', // other src/ imports
+    '^(api|context|hooks|constants|utils|components|pages|i18n|apps).*(?<![.]s?css)$', // other src/ imports, except for css files
     '^[./].*(?<![.]s?css)$', // relative imports except for css files
     '',
     '^classnames$',


### PR DESCRIPTION
Currently, if you import styles like

`components/Summary/styles.module.scss`

It will be next to, and mixed with, other absolute imports like `components/Summary/Header`.

This is something that only now came to light since we are now separating the main component file from its folder (we're no longer using `index.js` basically)

These changes will make the imports more consistent with what we already have, sorting them like:

```javacript
import Header from "components/Summary/Header"

import otherStyles from "components/Summary/styles.module.scss"
import styles from "./styles.module.scss"
```