### PR TITLE
Absolute imports regex is matching certain libs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullfabric/prettier-cfg",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullfabric/prettier-cfg",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "dependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullfabric/prettier-cfg",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Prettier config for FullFabric projects.",
   "main": "index.js",
   "scripts": {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -23,7 +23,7 @@ module.exports = {
     '^shared/?',
     '',
     '^(containers|reducers|actions)(/|$)', // for projects with redux
-    '^(api|context|hooks|constants|utils|components|pages|i18n|apps).*(?<![.]s?css)$', // other src/ imports, except for css files
+    '^(api|context|hooks|constants|utils|components|pages|i18n|apps)([/].+(?<![.]s?css)$|$)', // other absolute src/ imports, except for css files
     '^[./].*(?<![.]s?css)$', // relative imports except for css files
     '',
     '^classnames$',

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -27,6 +27,7 @@ module.exports = {
     '^[./].*(?<![.]s?css)$', // relative imports except for css files
     '',
     '^classnames$',
+    '^(api|context|hooks|constants|utils|components|pages|i18n|apps)[/].+[.]s?css$', // absolute style imports
     '[.]s?css$'
   ]
 }

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -1,3 +1,21 @@
+import React from 'react'
+
+import i18n from 'i18next'
+
+import { render } from '@testing-library/react'
+import { Text } from '@fullfabric/alma-mater'
+
+import renderApp from 'spec/helpers'
+
+import Header from 'components/Header'
+import locales from 'i18n/locales/en'
+import Body from '../Body'
+import Footer from './Footer'
+
+import classNames from 'classnames'
+import footerStyles from './Footer/styles.module.scss'
+import styles from 'components/Header/styles.module.scss'
+
 /**
  * Only used to run prettier against this, mostly as a way to check the config
  * is valid.

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -13,8 +13,9 @@ import Body from '../Body'
 import Footer from './Footer'
 
 import classNames from 'classnames'
-import footerStyles from './Footer/styles.module.scss'
 import styles from 'components/Header/styles.module.scss'
+import footerStyles from './Footer/styles.module.scss'
+import localStyles from './styles.module.scss'
 
 /**
  * Only used to run prettier against this, mostly as a way to check the config


### PR DESCRIPTION
Certain imports like `import i18n from 'i18next'` were matched to the absolute imports regex. This was because the last update stopped ensuring the end of the string after specific folders in absolute imports like `i18n`.

This quick fix does it.

Included a bunch of imports in the `index.spec.js` to simulate real world usage and test the config against. See the file in its current state to glimpse how the imports will be sorted